### PR TITLE
Fix sky check always true at or above sea level and ignoring liquids

### DIFF
--- a/src/main/java/owmii/lib/util/Misc.java
+++ b/src/main/java/owmii/lib/util/Misc.java
@@ -1,18 +1,15 @@
 package owmii.lib.util;
 
-import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class Misc {
+    /**
+     * Checks if the given block can see the sky.
+     * If the block itself blocks the sky, e.g. doesn't propagate skylight down, then check the block above it instead.
+     */
     public static boolean canBlockSeeSky(World world, BlockPos pos) {
-        BlockPos blockpos = new BlockPos(pos.getX(), world.getSeaLevel(), pos.getZ());
-        for (BlockPos down = blockpos.down(); down.getY() > pos.getY(); down = down.down()) {
-            BlockState blockstate = world.getBlockState(down);
-            if (blockstate.getOpacity(world, down) > 0 && !blockstate.getMaterial().isLiquid()) {
-                return false;
-            }
-        }
-        return true;
+        // world#canBlockSeeSky does not act like how it is named and is really used for guardian spawning check
+        return world.canSeeSky(pos);
     }
 }


### PR DESCRIPTION
Because when the starting blockpos was sea level, if the y pos was at or above sea level, the check was always succeeding.
Also it seemed to be ignoring liquids.

I think this was because the check was based off `IWorldReader#canBlockSeeSky` which is used for guardian spawn checking when the one intended is `IBlockDisplayReader#canSeeSky` so switched to using that and added some documentation for how to use the method.

Feel free to close this and switch to using `canSeeSky` directly. I think this utility method is only used in Powah's Solars atm. Let me know if this is desired and I can update the related PR in Powah too.