### PR TITLE
Add method for thread unsafe client setup

### DIFF
--- a/src/main/java/owmii/lib/api/IClient.java
+++ b/src/main/java/owmii/lib/api/IClient.java
@@ -2,6 +2,24 @@ package owmii.lib.api;
 
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
 public interface IClient {
+    /**
+     * Setting up the client in parallel.
+     * Only for code that is safe to run in parallel.
+     * e.g. uses a {@link ConcurrentHashMap}.
+     *
+     * @see IClient#syncClient(FMLClientSetupEvent)
+     */
     void client(FMLClientSetupEvent event);
+
+    /**
+     * Setting up the client on the main thread.
+     * For code that is unsafe to run in parallel.
+     * e.g. uses a {@link HashMap}.
+     */
+    default void syncClient(FMLClientSetupEvent event) {
+    }
 }

--- a/src/main/java/owmii/lib/api/IMod.java
+++ b/src/main/java/owmii/lib/api/IMod.java
@@ -2,6 +2,7 @@ package owmii.lib.api;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
@@ -57,6 +58,7 @@ public interface IMod {
         IClient mod = getClient();
         if (mod != null) {
             addModListener(mod::client);
+            addModListener((Consumer<FMLClientSetupEvent>) event -> event.enqueueWork(() -> mod.syncClient(event)));
         }
     }
 


### PR DESCRIPTION
This is for https://github.com/owmii/Powah/pull/154 and https://github.com/owmii/Lost-Trinkets/pull/57.
The method is for things that are not safe to be setup in parallel.
It is a default method to not break other mods that might not implement the method currently.