### PR TITLE
Enable colour in RenderTypes

### DIFF
--- a/src/main/java/owmii/lib/client/util/RenderTypes.java
+++ b/src/main/java/owmii/lib/client/util/RenderTypes.java
@@ -35,7 +35,7 @@ public class RenderTypes extends RenderType {
         State state = State.getBuilder().texture(new TextureState(location, false, false))
                 .transparency(BLENDED).diffuseLighting(DIFFUSE_LIGHTING_ENABLED).alpha(DEFAULT_ALPHA).cull(CULL_DISABLED)
                 .lightmap(LIGHTMAP_DISABLED).build(true);
-        return makeType("blend", DefaultVertexFormats.POSITION_TEX, 7, 256, true, true, state);
+        return makeType("blend", DefaultVertexFormats.POSITION_COLOR_TEX, 7, 256, true, true, state);
     }
 
     public static RenderType entityBlendedNoDept(ResourceLocation location) {
@@ -46,7 +46,7 @@ public class RenderTypes extends RenderType {
         State state = State.getBuilder().texture(new TextureState(location, false, false))
                 .transparency(BLENDED_NO_DEPT).diffuseLighting(DIFFUSE_LIGHTING_ENABLED).alpha(DEFAULT_ALPHA).cull(CULL_DISABLED)
                 .lightmap(LIGHTMAP_DISABLED).build(true);
-        return makeType("blend_bo_dept", DefaultVertexFormats.POSITION_TEX, 7, 256, true, true, state);
+        return makeType("blend_bo_dept", DefaultVertexFormats.POSITION_COLOR_TEX, 7, 256, true, true, state);
     }
 
     public static RenderType getTextBlended(ResourceLocation locationIn) {


### PR DESCRIPTION
For https://github.com/owmii/Powah/pull/163

This PR switches the vertex format to require colour information.

As far as I can tell, the first change is un-used (not in Powah or Lost Trinkets) so that change is just made in advance for when it might get used.

The second is used only by the Energizing Orb and Energizing Rod in the Powah mod.
